### PR TITLE
Exit read, write threads on web server shutdown

### DIFF
--- a/webui/server/server.py
+++ b/webui/server/server.py
@@ -10,7 +10,7 @@ from collections import OrderedDict
 from random import normalvariate
 
 import serial
-from aiohttp import web, WSMsgType
+from aiohttp import web, WSCloseCode, WSMsgType
 from aiohttp.web import json_response
 
 logger = logging.getLogger(__name__)
@@ -430,7 +430,7 @@ async def on_startup(app):
 
 async def on_shutdown(app):
   for ws in app['websockets']:
-    await ws.close(code=999, message='Server shutdown')
+    await ws.close(code=WSCloseCode.GOING_AWAY, message='Server shutdown')
   thread_stop_event.set()
 
 app = web.Application()

--- a/webui/server/server.py
+++ b/webui/server/server.py
@@ -19,9 +19,7 @@ logger = logging.getLogger(__name__)
 SERIAL_PORT = "/dev/ttyACM0"
 HTTP_PORT = 5000
 
-# Threads for the serial reader and writer.
-read_thread = None
-write_thread = None
+# Event to tell the reader and writer threads to exit.
 thread_stop_event = threading.Event()
 
 # Amount of panels.
@@ -221,6 +219,7 @@ class SerialHandler(object):
           self.Open()
           # Still not open, retry loop.
           if not self.ser:
+            time.sleep(1)
             continue
 
         try:
@@ -251,7 +250,10 @@ class SerialHandler(object):
 
   def Write(self):
     while not thread_stop_event.isSet():
-      command = self.write_queue.get()
+      try:
+        command = self.write_queue.get(timeout=1)
+      except queue.Empty:
+        continue
       if NO_SERIAL:
         if command[0] == 't':
           broadcast(['thresholds',
@@ -338,6 +340,7 @@ async def get_ws(request):
   ws = web.WebSocketResponse()
   await ws.prepare(request)
 
+  request.app['websockets'].append(ws)
   print('Client connected')
   profile_handler.MaybeLoad()
 
@@ -347,20 +350,6 @@ async def get_ws(request):
     'thresholds',
     {'thresholds': profile_handler.GetCurThresholds()},
   ])
-
-  global read_thread, write_thread
-
-  if not read_thread or not read_thread.is_alive():
-    print('Starting Read thread')
-    read_thread = threading.Thread(target=serial_handler.Read)
-    read_thread.daemon = True
-    read_thread.start()
-
-  if not write_thread or not write_thread.is_alive():
-    print('Starting Write thread')
-    write_thread = threading.Thread(target=serial_handler.Write)
-    write_thread.daemon = True
-    write_thread.start()
 
   # Potentially fetch any threshold values from the microcontroller that
   # may be out of sync with our profiles.
@@ -414,6 +403,7 @@ async def get_ws(request):
   except ConnectionResetError:
     pass
   finally:
+    request.app['websockets'].remove(ws)
     with out_queues_lock:
       out_queues.remove(queue)
 
@@ -431,8 +421,23 @@ build_dir = os.path.abspath(
 async def get_index(request):
   return web.FileResponse(os.path.join(build_dir, 'index.html'))
 
+async def on_startup(app):
+  read_thread = threading.Thread(target=serial_handler.Read)
+  read_thread.start()
+
+  write_thread = threading.Thread(target=serial_handler.Write)
+  write_thread.start()
+
+async def on_shutdown(app):
+  for ws in app['websockets']:
+    await ws.close(code=999, message='Server shutdown')
+  thread_stop_event.set()
 
 app = web.Application()
+
+# List of open websockets, to close when the app shuts down.
+app['websockets'] = []
+
 app.add_routes([
   web.get('/defaults', get_defaults),
   web.get('/ws', get_ws),
@@ -443,7 +448,8 @@ if not NO_SERIAL:
     web.get('/plot', get_index),
     web.static('/', build_dir),
   ])
-
+app.on_shutdown.append(on_shutdown)
+app.on_startup.append(on_startup)
 
 if __name__ == '__main__':
   hostname = socket.gethostname()


### PR DESCRIPTION
Proposed fix for #29

I found several potential reasons why child threads were not exiting.

1. thread_stop_event is read but never written
2. queue.Queue.get called in blocking mode without a timeout, preventing write thread from exiting
3. Web socket requests can restart threads. Not sure if this is strictly related, but it seems simpler to account for the threads if they are started once.
4. asyncio.queue.get is called with no timeout in the websocket handler, preventing it from exiting (it seems)

See also these notes on aiohttp graceful shutdown: https://docs.aiohttp.org/en/v0.22.4/web.html#aiohttp-web-graceful-shutdown

Address the above with the following changes

* Start read and write threads in on_startup instead of on websocket
connection
* Add shutdown handler to close websockets and set stop event
* Add timeout to queue get() so that reader can check whether it needs
to exit

Also

* Add sleep when retrying serial connect to reduce console noise and CPU
usage