### PR TITLE
Infer panel count in App.js from number of default threshold values

### DIFF
--- a/webui/src/App.js
+++ b/webui/src/App.js
@@ -515,7 +515,7 @@ function Plot() {
   );
 }
 
-function MainPartOfApp(props) {
+function FSRWebUI(props) {
   const { curValuesRef, emit, defaults, wsCallbacksRef } = props;
   const numPanels = defaults.thresholds.length;
   const [profiles, setProfiles] = useState(defaults.profiles);
@@ -613,6 +613,25 @@ function MainPartOfApp(props) {
   );
 }
 
+function LoadingScreen() {
+  return (
+    <div style={{ color: "white", height: "100vh", width: "100vw" }}>
+      <Navbar bg="light">
+        <Navbar.Brand as={"span"} to="/">FSR WebUI</Navbar.Brand>
+      </Navbar>
+      <div style={{
+        backgroundColor: "#282c34",
+        border: "1px solid white",
+        fontSize: "1.25rem",
+        padding: "0.5rem 1rem",
+        height: "96vh"
+      }}>
+        Connecting...
+      </div>
+    </div>
+  );
+}
+
 function WebSocketConnectionWrapper(props) {
   const { clearDefaults, defaults } = props;
   const numPanels = defaults.thresholds.length;
@@ -620,7 +639,7 @@ function WebSocketConnectionWrapper(props) {
 
   if (isWsReady) {
     return (
-      <MainPartOfApp
+      <FSRWebUI
         curValuesRef={curValuesRef}
         defaults={defaults}
         emit={emit}
@@ -628,15 +647,18 @@ function WebSocketConnectionWrapper(props) {
       />
     );
   } else {
-    return null;
+    return <LoadingScreen />
   }
 }
 
 function App() {
   const [defaults, setDefaults] = useState();
 
+  // Call this to clear the defaults and reload from the server.
+  // This also unmounts most of the app.
   const clearDefaults = useCallback(() => setDefaults(undefined), [setDefaults]);
 
+  // Load defaults at mount and reload any time they are cleared.
   useEffect(() => {
     let cleaningUp = false;
     let timeoutId = 0;
@@ -668,7 +690,7 @@ function App() {
   if (defaults) {
     return <WebSocketConnectionWrapper clearDefaults={clearDefaults} defaults={defaults} />
   } else {
-    return <div>Connecting</div>;
+    return <LoadingScreen />
   }
 }
 

--- a/webui/src/App.js
+++ b/webui/src/App.js
@@ -529,11 +529,15 @@ function App() {
 
   useEffect(() => {
     const wsCallbacks = wsCallbacksRef.current;
+    let cleaningUp = false;
 
     // Fetch all the default values the first time we load the page.
     // We will re-render after everything is fetched.
     if (!fetched) {
       fetch('/defaults').then(res => res.json()).then(data => {
+          if (cleaningUp) {
+            return;
+          }
           setProfiles(data.profiles);
           setActiveProfile(data.cur_profile);
           curValuesRef.current.kCurThresholds.length = 0
@@ -550,6 +554,7 @@ function App() {
     };
 
     return () => {
+      cleaningUp = true;
       delete wsCallbacks.get_profiles;
       delete wsCallbacks.get_cur_profile;
     };

--- a/webui/src/App.js
+++ b/webui/src/App.js
@@ -27,7 +27,7 @@ const MAX_SIZE = 1000;
 // Returned `defaults` property will be undefined if the defaults are loading or reloading.
 // Call `reloadDefaults` to clear the defaults and reload from the server.
 function useDefaults() {
-  const [defaults, setDefaults] = useState();
+  const [defaults, setDefaults] = useState(undefined);
 
   const reloadDefaults = useCallback(() => setDefaults(undefined), [setDefaults]);
 

--- a/webui/src/App.js
+++ b/webui/src/App.js
@@ -384,12 +384,12 @@ function ValueMonitor(props) {
 }
 
 function ValueMonitors(props) {
-  const { emit, numPanels} = props;
+  const { emit, numSensors} = props;
   return (
     <header className="App-header">
       <Container fluid style={{border: '1px solid white', height: '100vh'}}>
         <Row>
-          {[...Array(numPanels).keys()].map(index => (
+          {[...Array(numSensors).keys()].map(index => (
           	<ValueMonitor emit={emit} index={index} key={index} />)
           )}
         </Row>
@@ -571,7 +571,7 @@ function Plot() {
 
 function FSRWebUI(props) {
   const { curValuesRef, emit, defaults, wsCallbacksRef } = props;
-  const numPanels = defaults.thresholds.length;
+  const numSensors = defaults.thresholds.length;
   const [profiles, setProfiles] = useState(defaults.profiles);
   const [activeProfile, setActiveProfile] = useState(defaults.cur_profile);
   useEffect(() => {
@@ -655,7 +655,7 @@ function FSRWebUI(props) {
           </Navbar>
           <Switch>
             <Route exact path="/">
-              <ValueMonitors emit={emit} numPanels={numPanels} />
+              <ValueMonitors emit={emit} numSensors={numSensors} />
             </Route>
             <Route path="/plot">
               <Plot />

--- a/webui/src/App.js
+++ b/webui/src/App.js
@@ -329,7 +329,7 @@ function ValueMonitor(props) {
   );
 }
 
-function WebUI(props) {
+function ValueMonitors(props) {
   const { emit, numPanels} = props;
   return (
     <header className="App-header">
@@ -601,7 +601,7 @@ function FSRWebUI(props) {
           </Navbar>
           <Switch>
             <Route exact path="/">
-              <WebUI emit={emit} numPanels={numPanels} />
+              <ValueMonitors emit={emit} numPanels={numPanels} />
             </Route>
             <Route path="/plot">
               <Plot />
@@ -632,10 +632,10 @@ function LoadingScreen() {
   );
 }
 
-function WebSocketConnectionWrapper(props) {
-  const { clearDefaults, defaults } = props;
+function WsConnectionWrapper(props) {
+  const { defaults, reloadDefaults } = props;
   const numPanels = defaults.thresholds.length;
-  const { curValuesRef, emit, isWsReady, wsCallbacksRef } = useWsConnection({ onCloseWs: clearDefaults, numPanels });
+  const { curValuesRef, emit, isWsReady, wsCallbacksRef } = useWsConnection({ onCloseWs: reloadDefaults, numPanels });
 
   if (isWsReady) {
     return (
@@ -651,12 +651,12 @@ function WebSocketConnectionWrapper(props) {
   }
 }
 
-function App() {
+// Returned `defaults` property will be undefined if the defaults are loading or reloading.
+// Call `reloadDefaults` to clear the defaults and reload from the server.
+function useDefaults() {
   const [defaults, setDefaults] = useState();
 
-  // Call this to clear the defaults and reload from the server.
-  // This also unmounts most of the app.
-  const clearDefaults = useCallback(() => setDefaults(undefined), [setDefaults]);
+  const reloadDefaults = useCallback(() => setDefaults(undefined), [setDefaults]);
 
   // Load defaults at mount and reload any time they are cleared.
   useEffect(() => {
@@ -686,9 +686,15 @@ function App() {
     };
   }, [defaults]);
 
+  return { defaults, reloadDefaults };
+}
+
+function App() {
+  const { defaults, reloadDefaults } = useDefaults();
+
   // Don't render anything until the defaults are fetched.
   if (defaults) {
-    return <WebSocketConnectionWrapper clearDefaults={clearDefaults} defaults={defaults} />
+    return <WsConnectionWrapper defaults={defaults} reloadDefaults={reloadDefaults} />
   } else {
     return <LoadingScreen />
   }

--- a/webui/src/App.js
+++ b/webui/src/App.js
@@ -175,9 +175,7 @@ function useWsConnection({ defaults, onCloseWs }) {
 // An interactive display of the current values obtained by the backend.
 // Also has functionality to manipulate thresholds.
 function ValueMonitor(props) {
-  const index = parseInt(props.index)
-  const emit = props.emit;
-  const webUIDataRef = props.webUIDataRef;
+  const { emit, index, webUIDataRef } = props;
   const thresholdLabelRef = React.useRef(null);
   const valueLabelRef = React.useRef(null);
   const canvasRef = React.useRef(null);

--- a/webui/src/App.js
+++ b/webui/src/App.js
@@ -182,13 +182,13 @@ function ValueMonitor(props) {
   const curValues = webUIDataRef.current.curValues;
   const curThresholds = webUIDataRef.current.curThresholds;
 
-  function EmitValue(val) {
+  const EmitValue = useCallback((val) => {
     // Send back all the thresholds instead of a single value per sensor. This is in case
     // the server restarts where it would be nicer to have all the values in sync.
     // Still send back the index since we want to update only one value at a time
     // to the microcontroller.
     emit(['update_threshold', curThresholds, index]);
-  }
+  }, [curThresholds, emit, index])
 
   function Decrement(e) {
     const val = curThresholds[index] - 1;
@@ -359,11 +359,7 @@ function ValueMonitor(props) {
       cancelAnimationFrame(requestId);
       window.removeEventListener('resize', setDimensions);
     };
-  // Intentionally disable the lint errors.
-  // EmitValue and index don't need to be in the dependency list as we only want this to 
-  // run once. The canvas will automatically update via requestAnimationFrame.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [EmitValue, curThresholds, curValues, index, webUIDataRef]);
 
   return(
     <Col style={{height: '75vh', paddingTop: '1vh'}}>

--- a/webui/src/App.js
+++ b/webui/src/App.js
@@ -111,10 +111,6 @@ function useWsConnection({ defaults, onCloseWs }) {
       webUIData.curValues[webUIData.oldest] = msg.values;
       webUIData.oldest = (webUIData.oldest + 1) % MAX_SIZE;
     }
-    if (webUIData.curValues.length === 1) {
-      // WebSocket is considered ready after it gets its first "values" message.
-      setIsWsReady(true);
-    }
   };
 
   wsCallbacksRef.current.thresholds = function(msg) {
@@ -132,8 +128,9 @@ function useWsConnection({ defaults, onCloseWs }) {
       return;
     }
 
-    // Ensure values history is empty and default thresholds are set.
+    // Ensure values history reset and default thresholds are set.
     webUIData.curValues.length = 0;
+    webUIData.curValues.push(new Array(defaults.thresholds.length).fill(0));
     webUIData.oldest = 0;
     webUIDataRef.current.curThresholds.length = 0;
     webUIDataRef.current.curThresholds.push(...defaults.thresholds);
@@ -141,6 +138,10 @@ function useWsConnection({ defaults, onCloseWs }) {
     const ws = new WebSocket('ws://' + window.location.host + '/ws');
     wsRef.current = ws;
 
+    ws.addEventListener('open', function(ev) {
+      setIsWsReady(true);
+    });
+    
     ws.addEventListener('error', function(ev) {
       ws.close();
     });

--- a/webui/src/App.js
+++ b/webui/src/App.js
@@ -623,17 +623,26 @@ function App() {
 
   useEffect(() => {
     let cleaningUp = false;
+    let timeoutId = 0;
 
-    // Fetch all the default values the first time we load the page.
-    // We will re-render after everything is fetched.
-    fetch('/defaults').then(res => res.json()).then(data => {
-      if (!cleaningUp) {
-        setDefaults(data);
-      }
-    });
+    const getDefaults = () => {
+      clearTimeout(timeoutId);
+      fetch('/defaults').then(res => res.json()).then(data => {
+        if (!cleaningUp) {
+          setDefaults(data);
+        }
+      }).catch(reason => {
+        if (!cleaningUp) {
+          timeoutId = setTimeout(getDefaults, 1000);
+        }
+      });
+    }
+
+    getDefaults();
 
     return () => {
       cleaningUp = true;
+      clearTimeout(timeoutId);
     };
   }, []);
 
@@ -641,7 +650,7 @@ function App() {
   if (defaults) {
     return <MainPartOfApp defaults={defaults} />
   } else {
-    return null;
+    return <div>Connecting</div>;
   }
 }
 

--- a/webui/src/App.js
+++ b/webui/src/App.js
@@ -22,7 +22,7 @@ import {
 } from "react-router-dom";
 
 // Maximum number of historical sensor values to retain
-const max_size = 1000;
+const MAX_SIZE = 1000;
 
 // Reference to history of current sensor values.
 // The values are stored in a mutable array in a ref so that they are not
@@ -82,7 +82,7 @@ function useWsConnection({ defaults, onCloseWs }) {
 
   const curValuesRef = useRef({
 
-    // A history of the past 'max_size' values fetched from the backend.
+    // A history of the past 'MAX_SIZE' values fetched from the backend.
     // Used for plotting and displaying live values.
     // We use a cyclical array to save memory.
     kCurValues: [],
@@ -106,11 +106,11 @@ function useWsConnection({ defaults, onCloseWs }) {
 
   wsCallbacksRef.current.values = function(msg) {
     const curValues = curValuesRef.current;
-    if (curValues.kCurValues.length < max_size) {
+    if (curValues.kCurValues.length < MAX_SIZE) {
       curValues.kCurValues.push(msg.values);
     } else {
       curValues.kCurValues[curValues.oldest] = msg.values;
-      curValues.oldest = (curValues.oldest + 1) % max_size;
+      curValues.oldest = (curValues.oldest + 1) % MAX_SIZE;
     }
     if (curValues.kCurValues.length === 1) {
       // WebSocket is considered ready after it gets its first "values" message.
@@ -305,10 +305,10 @@ function ValueMonitor(props) {
       // Get the latest value. This is either last element in the list, or based off of
       // the circular array.
       let currentValue = 0;
-      if (kCurValues.length < max_size) {
+      if (kCurValues.length < MAX_SIZE) {
         currentValue = kCurValues[kCurValues.length-1][index];
       } else {
-        currentValue = kCurValues[((oldest - 1) % max_size + max_size) % max_size][index];
+        currentValue = kCurValues[((oldest - 1) % MAX_SIZE + MAX_SIZE) % MAX_SIZE][index];
       }
 
       // Add background fill.
@@ -471,21 +471,21 @@ function Plot() {
       }
 
       // Plot the line graph for each of the sensors.
-      const px_per_div = box_width/max_size;
+      const px_per_div = box_width/MAX_SIZE;
       for (let i = 0; i < 4; ++i) {
         if (display[i]) {
           ctx.beginPath();
           ctx.setLineDash([]);
           ctx.strokeStyle = colors[i];
           ctx.lineWidth = 2;
-          for (let j = 0; j < max_size; ++j) {
+          for (let j = 0; j < MAX_SIZE; ++j) {
             if (j === kCurValues.length) { break; }
             if (j === 0) {
               ctx.moveTo(spacing,
-                box_height - box_height * kCurValues[(j + oldest) % max_size][i]/1023 + spacing);
+                box_height - box_height * kCurValues[(j + oldest) % MAX_SIZE][i]/1023 + spacing);
             } else {
               ctx.lineTo(px_per_div*j + spacing,
-                box_height - box_height * kCurValues[(j + oldest) % max_size][i]/1023 + spacing);
+                box_height - box_height * kCurValues[(j + oldest) % MAX_SIZE][i]/1023 + spacing);
             }
           }
           ctx.stroke();
@@ -510,11 +510,11 @@ function Plot() {
       for (let i = 0; i < 4; ++i) {
         if (display[i]) {
           ctx.fillStyle = colors[i];
-          if (kCurValues.length < max_size) {
+          if (kCurValues.length < MAX_SIZE) {
             ctx.fillText(kCurValues[kCurValues.length-1][i], 100 + i * 100, 100);
           } else {
             ctx.fillText(
-              kCurValues[((oldest - 1) % max_size + max_size) % max_size][i], 100 + i * 100, 100);
+              kCurValues[((oldest - 1) % MAX_SIZE + MAX_SIZE) % MAX_SIZE][i], 100 + i * 100, 100);
           }
         }
       }


### PR DESCRIPTION
The high level goal here is to allow the React app to accommodate an unknown number of panels without code changes or rebuilding.

I tried to focus on that in this branch and not make too many unrelated changes. However, I did still make some opinionated changes.

I moved some module-level state such as kCurValues, kCurThresholds, and ws into hooks and refs. This has two benefits IMO.

First, the server can shut down and come back with a different number of sensors configured, and the app will handle this gracefully without a page reload. This is not a super important feature, but it demonstrates the second benefit, which is that more resources are managed by React and so their lifetime is well defined including how to clean them up without reloading the page.

I like this style better, but it is more complicated in some ways. There is definitely a simplicity to cleaning up state by reloading the whole page.

I tried to adopt a similar change without refactoring `connect()`. I think it works okay but I wasn't as happy with it. https://github.com/teejusb/fsr/compare/b89e5228b...joshhead:js-detect-panel-count-minimal?expand=1