### PR TITLE
Fit more ValueMonitors without breaking layout

### DIFF
--- a/webui/src/App.css
+++ b/webui/src/App.css
@@ -25,3 +25,25 @@
 .App-link {
   color: #61dafb;
 }
+
+.ValueMonitor-row {
+  height: 100%;
+  overflow: hidden;
+}
+
+.ValueMonitor-col {
+  display: flex;
+  flex-direction: column;
+}
+
+.ValueMonitor-canvas {
+  border: 1px solid white;
+  touch-action: none;
+  flex: 1 0 auto;
+  height: 0;
+}
+
+.ValueMonitor-buttons,
+.ValueMonitor-label {
+  flex: 0 0 auto;
+}

--- a/webui/src/App.js
+++ b/webui/src/App.js
@@ -362,32 +362,47 @@ function ValueMonitor(props) {
   }, [EmitValue, curThresholds, curValues, index, webUIDataRef]);
 
   return(
-    <Col style={{height: '75vh', paddingTop: '1vh'}}>
-      <Button variant="light" size="sm" onClick={Decrement}><b>-</b></Button>
-      <span> </span>
-      <Button variant="light" size="sm" onClick={Increment}><b>+</b></Button>
-      <br />
-      <Form.Label ref={thresholdLabelRef}>0</Form.Label>
-      <br />
-      <Form.Label ref={valueLabelRef}>0</Form.Label>
+    <Col className="ValueMonitor-col">
+      <div className="ValueMonitor-buttons">
+        <Button variant="light" size="sm" onClick={Decrement}><b>-</b></Button>
+        <span> </span>
+        <Button variant="light" size="sm" onClick={Increment}><b>+</b></Button>
+      </div>
+      <Form.Label className="ValueMonitor-label" ref={thresholdLabelRef}>0</Form.Label>
+      <Form.Label className="ValueMonitor-label" ref={valueLabelRef}>0</Form.Label>
       <canvas
+        className="ValueMonitor-canvas"
         ref={canvasRef}
-        style={{border: '1px solid white', width: '100%', height: '100%', touchAction: "none"}} />
+      />
     </Col>
   );
 }
 
 function ValueMonitors(props) {
-  const { emit, numSensors, webUIDataRef} = props;
+  const { numSensors } = props;
   return (
     <header className="App-header">
       <Container fluid style={{border: '1px solid white', height: '100vh'}}>
-        <Row>
-          {[...Array(numSensors).keys()].map(index => (
-          	<ValueMonitor emit={emit} index={index} key={index} webUIDataRef={webUIDataRef} />)
-          )}
+        <Row className="ValueMonitor-row">
+          {props.children}
         </Row>
       </Container>
+      <style>
+        {`
+        .ValueMonitor-col {
+          width: ${100 / numSensors}%;
+        }
+        /* 15 + 15 is left and right padding (from bootstrap col class). */
+        /* 75 is the minimum desired width of the canvas. */
+        /* If there is not enough room for all columns and padding to fit, reduce padding. */
+        @media (max-width: ${numSensors * (15 + 15 + 75)}px) {
+          .ValueMonitor-col {
+            padding-left: 1px;
+            padding-right: 1px;
+          }
+        }
+        `}
+      </style>
     </header>
   );
 }
@@ -648,7 +663,11 @@ function FSRWebUI(props) {
         </Navbar>
         <Switch>
           <Route exact path="/">
-            <ValueMonitors emit={emit} numSensors={numSensors} webUIDataRef={webUIDataRef} />
+            <ValueMonitors numSensors={numSensors}>
+              {[...Array(numSensors).keys()].map(index => (
+                <ValueMonitor emit={emit} index={index} key={index} webUIDataRef={webUIDataRef} />)
+              )}
+            </ValueMonitors>
           </Route>
           <Route path="/plot">
             <Plot webUIDataRef={webUIDataRef} />


### PR DESCRIPTION
Improve the fit of value monitor columns when space is tight.

When adding extra sensors, the layout can break, with sensors wrapping to a second row.

I tried to leave the layout alone mostly, for the case where there is enough room for all the columns, but the spacing is a little different on top and below. I wasn't totally clear on the intended spacing since the columns were extending beyond the height of the row in the layout, but it should be easy to add space below if desired.

|master|fit-more-value-monitors|
|-|-|
|<img width="2672" alt="Screen Shot 2022-02-05 at 11 30 58 PM" src="https://user-images.githubusercontent.com/1121222/152914880-fed8274a-5eaa-4174-804e-df3a9b81c320.png">|<img width="2672" alt="Screen Shot 2022-02-05 at 11 29 39 PM" src="https://user-images.githubusercontent.com/1121222/152914882-0675c43c-1938-43c4-a8b5-7f83d18fbbd0.png">|
|<img width="612" alt="Screen Shot 2022-02-07 at 9 38 25 PM" src="https://user-images.githubusercontent.com/1121222/152914873-04d66642-af9c-4655-8365-be7b5e170cc8.png">|<img width="612" alt="Screen Shot 2022-02-07 at 9 37 11 PM" src="https://user-images.githubusercontent.com/1121222/152914876-f5847e95-9350-422b-a3ca-103edf96e7c5.png">|
|<img width="2672" alt="Screen Shot 2022-02-05 at 11 27 04 PM" src="https://user-images.githubusercontent.com/1121222/152915130-857cdafb-2fac-4867-8f85-becf0ea7d33e.png">|<img width="2672" alt="Screen Shot 2022-02-05 at 11 28 05 PM" src="https://user-images.githubusercontent.com/1121222/152914887-526dc8ae-951a-4688-9547-9c5403f644e3.png">|

