### PR TITLE
Support threshold updates for more than 10 sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Follow a guide like [fsr-pad-guide](https://github.com/Sereni/fsr-pad-guide) or 
 ### Testing and using the serial monitor
 1. Open `Tools` > `Serial Monitor` to open the Serial Monitor
 1. Within the serial monitor, enter `t` to show current thresholds.
-1. You can change a sensor threshold by entering numbers, where the first number is the sensor (0-indexed) followed by the threshold value. For example, `3180` would set the 4th sensor to 180 thresholds.  You can change these more easily in the UI later.
+1. You can change a sensor threshold by entering numbers, where the first number is the sensor (0-indexed) followed by the threshold value. For example, `3 180` would set the 4th sensor to 180 thresholds.  You can change these more easily in the UI later.
 1. Enter `v` to get the current sensor values.
 1. Putting pressure on an FSR, you should notice the values change if you enter `v` again while maintaining pressure.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Follow a guide like [fsr-pad-guide](https://github.com/Sereni/fsr-pad-guide) or 
 ### Testing and using the serial monitor
 1. Open `Tools` > `Serial Monitor` to open the Serial Monitor
 1. Within the serial monitor, enter `t` to show current thresholds.
-1. You can change a sensor threshold by entering numbers, where the first number is the sensor (0-indexed) followed by the threshold value. For example, `3 180` would set the 4th sensor to 180 thresholds.  You can change these more easily in the UI later.
+1. You can change a sensor threshold by entering numbers, where the first number is the sensor (0-indexed) followed by the threshold value. For example, `3 180` would set the 4th sensor to a threshold of 180.  You can change these more easily in the UI later.
 1. Enter `v` to get the current sensor values.
 1. Putting pressure on an FSR, you should notice the values change if you enter `v` again while maintaining pressure.
 

--- a/fsr.ino
+++ b/fsr.ino
@@ -473,16 +473,7 @@ class SerialProcessor {
         case 'T':
           PrintThresholds();
           break;
-        case '0':
-        case '1':
-        case '2':
-        case '3':
-        case '4':
-        case '5':
-        case '6':
-        case '7':
-        case '8':
-        case '9':
+        case '0' ... '9': // Case ranges are non-standard but work in gcc
           UpdateAndPrintThreshold(bytes_read);
         default:
           break;

--- a/fsr.ino
+++ b/fsr.ino
@@ -473,8 +473,18 @@ class SerialProcessor {
         case 'T':
           PrintThresholds();
           break;
-        default:
+        case '0':
+        case '1':
+        case '2':
+        case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7':
+        case '8':
+        case '9':
           UpdateAndPrintThreshold(bytes_read);
+        default:
           break;
       }
     }  
@@ -482,19 +492,20 @@ class SerialProcessor {
 
   void UpdateAndPrintThreshold(size_t bytes_read) {
     // Need to specify:
-    // Sensor number + Threshold value.
-    // {0, 1, 2, 3} + "0"-"1023"
-    // e.g. 3180 (fourth FSR, change threshold to 180)
+    // Sensor number + Threshold value, separated by a space.
+    // {0, 1, 2, 3,...} + "0"-"1023"
+    // e.g. 3 180 (fourth FSR, change threshold to 180)
     
-    if (bytes_read < 2 || bytes_read > 5) { return; }
-    
-    size_t sensor_index = buffer_[0] - '0';
-    //this works for chars < '0' because they will
-    //also be > kNumSensors due to uint underflow.
+    if (bytes_read < 3 || bytes_read > 7) { return; }
+
+    char* next = nullptr;
+    size_t sensor_index = strtoul(buffer_, &next, 10);
     if (sensor_index >= kNumSensors) { return; }
 
-    kSensors[sensor_index].UpdateThreshold(
-        strtoul(buffer_ + 1, nullptr, 10));
+    int16_t sensor_threshold = strtol(next, nullptr, 10);
+    if (sensor_threshold < 0 || sensor_threshold > 1023) { return; }
+
+    kSensors[sensor_index].UpdateThreshold(sensor_threshold);
     PrintThresholds();
   }
 

--- a/webui/server/server.py
+++ b/webui/server/server.py
@@ -22,11 +22,11 @@ HTTP_PORT = 5000
 # Event to tell the reader and writer threads to exit.
 thread_stop_event = threading.Event()
 
-# Amount of panels.
-num_panels = 4
+# Amount of sensors.
+num_sensors = 4
 
-# Initialize panel ids.
-sensor_numbers = range(num_panels)
+# Initialize sensor ids.
+sensor_numbers = range(num_sensors)
 
 # Used for developmental purposes. Set this to true when you just want to
 # emulate the serial device instead of actually connecting to one.
@@ -49,7 +49,7 @@ class ProfileHandler(object):
     self.profiles = OrderedDict()
     self.cur_profile = ''
     # Have a default no-name profile we can use in case there are no profiles.
-    self.profiles[''] = [0] * num_panels
+    self.profiles[''] = [0] * num_sensors
     self.loaded = False
 
   def MaybeLoad(self):
@@ -59,7 +59,7 @@ class ProfileHandler(object):
         with open(self.filename, 'r') as f:
           for line in f:
             parts = line.split()
-            if len(parts) == (num_panels+1):
+            if len(parts) == (num_sensors+1):
               self.profiles[parts[0]] = [int(x) for x in parts[1:]]
               num_profiles += 1
               # Change to the first profile found.
@@ -104,7 +104,7 @@ class ProfileHandler(object):
   def AddProfile(self, profile_name, thresholds):
     self.profiles[profile_name] = thresholds
     if self.cur_profile == '':
-      self.profiles[''] = [0] * num_panels
+      self.profiles[''] = [0] * num_sensors
     # ChangeProfile emits 'thresholds' and 'cur_profile'
     self.ChangeProfile(profile_name)
     with open(self.filename, 'w') as f:
@@ -151,12 +151,12 @@ class SerialHandler(object):
     self.ser = None
     self.port = port
     self.timeout = timeout
-    self.write_queue = queue.Queue(num_panels + 10)
+    self.write_queue = queue.Queue(num_sensors + 10)
     self.profile_handler = profile_handler
 
     # Use this to store the values when emulating serial so the graph isn't too
     # jumpy. Only used when NO_SERIAL is true.
-    self.no_serial_values = [0] * num_panels
+    self.no_serial_values = [0] * num_sensors
 
   def ChangePort(self, port):
     if self.ser:
@@ -190,7 +190,7 @@ class SerialHandler(object):
     def ProcessValues(values):
       # Fix our sensor ordering.
       actual = []
-      for i in range(num_panels):
+      for i in range(num_sensors):
         actual.append(values[sensor_numbers[i]])
       broadcast(['values', {'values': actual}])
       time.sleep(0.01)
@@ -199,7 +199,7 @@ class SerialHandler(object):
       cur_thresholds = self.profile_handler.GetCurThresholds()
       # Fix our sensor ordering.
       actual = []
-      for i in range(num_panels):
+      for i in range(num_sensors):
         actual.append(values[sensor_numbers[i]])
       for i, (cur, act) in enumerate(zip(cur_thresholds, actual)):
         if cur != act:
@@ -207,10 +207,10 @@ class SerialHandler(object):
 
     while not thread_stop_event.isSet():
       if NO_SERIAL:
-        offsets = [int(normalvariate(0, num_panels+1)) for _ in range(num_panels)]
+        offsets = [int(normalvariate(0, num_sensors+1)) for _ in range(num_sensors)]
         self.no_serial_values = [
           max(0, min(self.no_serial_values[i] + offsets[i], 1023))
-          for i in range(num_panels)
+          for i in range(num_sensors)
         ]
         broadcast(['values', {'values': self.no_serial_values}])
         time.sleep(0.01)
@@ -233,7 +233,7 @@ class SerialHandler(object):
           # All commands are of the form:
           #   cmd num1 num2 num3 num4
           parts = line.split()
-          if len(parts) != num_panels+1:
+          if len(parts) != num_sensors+1:
             continue
           cmd = parts[0]
           values = [int(x) for x in parts[1:]]

--- a/webui/server/server.py
+++ b/webui/server/server.py
@@ -151,8 +151,7 @@ class SerialHandler(object):
     self.ser = None
     self.port = port
     self.timeout = timeout
-    # Sized for `num_panels` threshold updates plus one "v" command
-    self.write_queue = queue.Queue(num_panels + 1)
+    self.write_queue = queue.Queue(num_panels + 10)
     self.profile_handler = profile_handler
 
     # Use this to store the values when emulating serial so the graph isn't too
@@ -179,7 +178,7 @@ class SerialHandler(object):
       if self.ser:
         # Apply currently loaded thresholds when the microcontroller connects.
         for i, threshold in enumerate(self.profile_handler.GetCurThresholds()):
-          threshold_cmd = str(sensor_numbers[i]) + ' ' + str(threshold) + '\n'
+          threshold_cmd = '%d %d\n' % (sensor_numbers[i], threshold)
           self.write_queue.put(threshold_cmd, block=False)
     except queue.Full as e:
       logger.error('Could not set thresholds. Queue full.')
@@ -287,7 +286,7 @@ serial_handler = SerialHandler(profile_handler, port=SERIAL_PORT)
 def update_threshold(values, index):
   try:
     # Let the writer thread handle updating thresholds.
-    threshold_cmd = str(sensor_numbers[index]) + ' ' + str(values[index]) + '\n'
+    threshold_cmd = '%d %d\n' % (sensor_numbers[index], values[index])
     serial_handler.write_queue.put(threshold_cmd, block=False)
   except queue.Full:
     logger.error('Could not update thresholds. Queue full.')


### PR DESCRIPTION
Instead of assuming sensor indexes are exactly one digit, separate sensor index and value with a space to allow two digit indexes.

Command changes from e.g. `3180` to `3 180` to update 4th sensor threshold to 180.
This means it is now possible to configure more than 10 sensors and set the threshold as in `10 180` or `16 1023`.

Because of the command format changes, MCUs will need to be reflashed. Just by luck, pads that do not update the firmware right away will still respond correctly to thresholds that are less than 4 digits. Because the `strtol` function used to parse the threshold value ignores leading whitespace, a threshold of `" 400"` will still parse correctly as `400`. The older code will however ignore commands longer than 5 bytes such as `1 1001`.

This would replace #33 