### PR TITLE
Don't send ChangeProfile "X" when deleting profile

### DIFF
--- a/webui/src/App.js
+++ b/webui/src/App.js
@@ -610,6 +610,8 @@ function FSRWebUI(props) {
   }
 
   function RemoveProfile(e) {
+    // The X button is inside the Change Profile button, so stop the event from bubbling up and triggering the ChangeProfile handler.
+    e.stopPropagation();
     // Strip out the "X " added by the button.
     const profile_name = e.target.parentNode.innerText.replace('X ', '');
     emit(['remove_profile', profile_name]);


### PR DESCRIPTION
Because the X button is inside a NavDropdown.Item with `onClick={ChangeProfile}`, the click event bubbles up and triggers ChangeProfile (with the text of the event target, "X") after RemoveProfile. Call `stopPropagation` to prevent the event from bubbling up.

This doesn't cause any problems since ProfileHandler ignores requests to change to unknown profiles, but I don't think it's intended behavior in App.js.

Before

<img width="657" alt="Screen Shot 2022-02-10 at 12 33 32 AM" src="https://user-images.githubusercontent.com/1121222/153344552-fa6ea926-5989-4a25-becb-3c4e8a103a6d.png">

After

<img width="645" alt="Screen Shot 2022-02-10 at 12 45 32 AM" src="https://user-images.githubusercontent.com/1121222/153345261-5dee3edd-32d3-4901-b0e3-bac054a96a93.png">
