### PR TITLE
Support more or fewer than 4 sensors on plot

### DIFF
--- a/webui/src/App.css
+++ b/webui/src/App.css
@@ -47,3 +47,13 @@
 .ValueMonitor-label {
   flex: 0 0 auto;
 }
+
+.ToggleButton-plot-sensor {
+  margin-right: 0.75em;
+}
+
+.ToggleButton-plot-sensor > input {
+  position: absolute;
+  clip: rect(0,0,0,0);
+  pointer-events: none;
+}

--- a/webui/src/App.js
+++ b/webui/src/App.js
@@ -487,7 +487,7 @@ function Plot(props) {
 
       // Plot the line graph for each of the sensors.
       const px_per_div = box_width/MAX_SIZE;
-      for (let i = 0; i < numSensors; i++) {
+      for (let i = 0; i < numSensors; ++i) {
         if (display[i]) {
           ctx.beginPath();
           ctx.setLineDash([]);
@@ -543,7 +543,7 @@ function Plot(props) {
       cancelAnimationFrame(requestId);
       window.removeEventListener('resize', setDimensions);
     };
-  }, [colors, curThresholds, curValues, darkColors, display, numSensors, webUIDataRef])
+  }, [colors, curThresholds, curValues, darkColors, display, numSensors, webUIDataRef]);
 
   const ToggleLine = (index) => {
     setDisplay(display => {

--- a/webui/src/App.js
+++ b/webui/src/App.js
@@ -512,7 +512,7 @@ function Plot(props) {
         if (display[i]) {
           ctx.beginPath();
           ctx.setLineDash([]);
-          ctx.strokeStyle = colors[i];
+          ctx.strokeStyle = darkColors[i];
           ctx.lineWidth = 2;
           ctx.moveTo(spacing, box_height - box_height * curThresholds[i]/1023 + spacing);
           ctx.lineTo(box_width + spacing, box_height - box_height * curThresholds[i]/1023 + spacing);
@@ -563,8 +563,8 @@ function Plot(props) {
         checked={display[i]}
         variant={display[i] ? "light" : "secondary"}
         size="sm"
-        onChange={() => ToggleLine(i)
-      }>
+        onChange={() => ToggleLine(i)}
+      >
         <b style={{color: display[i] ? darkColors[i] : "#f8f9fa"}}>
           {numSensors === buttonNames.length ? buttonNames[i] : i}
         </b>


### PR DESCRIPTION
Draw a variable number of lines and toggle buttons for the plot view depending on the number of sensors, instead of hardcoding 4 sensors.

Set the stroke style when drawing the border and divisions to make them gray instead of having them match the color of the last selected sensor line.

The examples below are both configured with 8 sensors and random fake serial data.

Before
<img width="788" alt="Screen Shot 2022-02-10 at 1 37 50 AM" src="https://user-images.githubusercontent.com/1121222/153351860-55877053-a457-4cfb-863b-26927ebc08ea.png">

After
<img width="787" alt="Screen Shot 2022-02-10 at 1 38 57 AM" src="https://user-images.githubusercontent.com/1121222/153351878-1489355e-e5e6-4f05-9d62-50c76b75d69b.png">

