### PR TITLE
Support newer python versions

### DIFF
--- a/webui/server/requirements.txt
+++ b/webui/server/requirements.txt
@@ -1,5 +1,5 @@
-aiohttp==3.7.4.post0
-async-timeout==3.0.1
+aiohttp==3.8.1
+async-timeout==4.0.2
 attrs==21.2.0
 chardet==4.0.0
 idna==3.2

--- a/webui/server/server.py
+++ b/webui/server/server.py
@@ -205,7 +205,7 @@ class SerialHandler(object):
         if cur != act:
           self.profile_handler.UpdateThresholds(i, act)
 
-    while not thread_stop_event.isSet():
+    while not thread_stop_event.is_set():
       if NO_SERIAL:
         offsets = [int(normalvariate(0, num_sensors+1)) for _ in range(num_sensors)]
         self.no_serial_values = [
@@ -249,7 +249,7 @@ class SerialHandler(object):
           self.Open()
 
   def Write(self):
-    while not thread_stop_event.isSet():
+    while not thread_stop_event.is_set():
       try:
         command = self.write_queue.get(timeout=1)
       except queue.Empty:
@@ -324,14 +324,14 @@ async def get_defaults(request):
 
 out_queues = set()
 out_queues_lock = threading.Lock()
-main_thread_loop = asyncio.get_event_loop()
+loop = None
 
 
 def broadcast(msg):
   with out_queues_lock:
     for q in out_queues:
       try:
-        main_thread_loop.call_soon_threadsafe(q.put_nowait, msg)
+        loop.call_soon_threadsafe(q.put_nowait, msg)
       except asyncio.queues.QueueFull:
         pass
 
@@ -421,6 +421,9 @@ async def get_index(request):
   return web.FileResponse(os.path.join(build_dir, 'index.html'))
 
 async def on_startup(app):
+  global loop
+  loop = asyncio.get_event_loop()
+
   profile_handler.MaybeLoad()
 
   read_thread = threading.Thread(target=serial_handler.Read)


### PR DESCRIPTION
Newer versions of python (e.g. 3.10) need upgraded aiohttp, otherwise there are weird issues with Ctrl+C (see issue).

However, doing so also requires calling asyncio.get_event_loop() after web.run_app() because now asyncio.get_event_loop() doesn't return a loop if one isn't set. web.run_app() sets one.

Fixes #48