### PR TITLE
Add support for analog multiplexers

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Follow a guide like [fsr-pad-guide](https://github.com/Sereni/fsr-pad-guide) or 
 1. In Arduino IDE, set the `Tools` > `Board` to your microcontroller (e.g. `Teensy 4.0`)
 1. In Arduino IDE, set the `Tools` > `Port` to select the serial port for the plugged in microcontroller (e.g. `COM5` or `/dev/something`)
 1. Load [fsr.ino](./fsr.ino) in Arduino IDE.
-1. By default, [A0-A3 are the pins](https://forum.pjrc.com/teensy40_pinout1.png) used for the FSR sensors in this software. If you aren't using these pins [alter the SensorState array](./fsr.ino#L437-L442)
+1. By default, [A0-A3 are the pins](https://forum.pjrc.com/teensy40_pinout1.png) used for the FSR sensors in this software. If you aren't using these pins [alter the SensorState array](./fsr.ino#L658-L663)
 1. Push the code to the board
 
 ### Testing and using the serial monitor

--- a/fsr.ino
+++ b/fsr.ino
@@ -584,7 +584,7 @@ class Sensor {
 
   // The default sensor reader reads an analog pin with Arduino's analogRead
   // function. A custom SensorReader can be used to do things like configure
-  // a multiplexer before reading, or read from an ADC connected with a sen
+  // a multiplexer before reading, or read from an ADC connected with a SPI
   // or 2-wire interface.
   ISensorReader* sensor_reader_;
   // Used to indicate if the sensor reader is owned by this instance, or if it

--- a/fsr.ino
+++ b/fsr.ino
@@ -144,22 +144,22 @@ class IMux {
 class Mux : public IMux {
   public:
     // 4 bits, 16 channels
-    Mux(pin_size_t pin_a, pin_size_t pin_b, pin_size_t pin_c, pin_size_t pin_d)
+    Mux(uint8_t pin_a, uint8_t pin_b, uint8_t pin_c, uint8_t pin_d)
         : initialized_(false), num_bits_(4),
         pin_a_(pin_a), pin_b_(pin_b), pin_c_(pin_c), pin_d_(pin_d) {}
 
     // 3 bits, 8 channels
-    Mux(pin_size_t pin_a, pin_size_t pin_b, pin_size_t pin_c)
+    Mux(uint8_t pin_a, uint8_t pin_b, uint8_t pin_c)
         : initialized_(false), num_bits_(3),
         pin_a_(pin_a), pin_b_(pin_b), pin_c_(pin_c), pin_d_(pin_c) {}
 
     // 2 bits, 4 channels
-    Mux(pin_size_t pin_a, pin_size_t pin_b)
+    Mux(uint8_t pin_a, uint8_t pin_b)
         : initialized_(false), num_bits_(2),
         pin_a_(pin_a), pin_b_(pin_b), pin_c_(pin_b), pin_d_(pin_b) {}
 
     // 1 bit, 2 channels
-    Mux(pin_size_t pin_a)
+    Mux(uint8_t pin_a)
         : initialized_(false), num_bits_(1),
         pin_a_(pin_a), pin_b_(pin_a), pin_c_(pin_a), pin_d_(pin_a) {}
 

--- a/fsr.ino
+++ b/fsr.ino
@@ -474,6 +474,9 @@ class Sensor {
         should_delete_state_(false) {}
   
   ~Sensor() {
+    if (should_delete_sensor_reader_) {
+      delete sensor_reader_;
+    }
     if (should_delete_state_) {
       delete sensor_state_;
     }


### PR DESCRIPTION
I'm planning to use a multiplexer with a Pi Pico, which only breaks out 3 analog pins. Are you interested in supporting multiplexers upstream?

The primary use case is to add additional sensors with an analog multiplexer breakout like https://www.sparkfun.com/products/9056. Similar boards with the same multiplexer chip can be found on Amazon and AliExpress. This makes it possible to more easily use 4 analog inputs a Pi Pico, or say, 20 inputs on a Teensy 4.0.

I also wrote this with some other more hypothetical use cases in mind, which might help explain the interfaces I picked. An external ADC with SPI, i2C, or parallel interface. An ISensorReader that reads multiple sensors and adds, averages, or otherwise combines them to present one composite sensor value with a single threshold. I don't know if I'll pursue these but they should be possible to add without much refactoring, by only adding new sensor reader classes.

I'm interested in feedback on the general approach before cleaning it up further, but it's working on my desk using a Pi Pico and CD4051B 8:1 multiplexer. I'm planning to test with a CD74HC4067 16:1 multiplexer once it comes in the mail.

