### PR TITLE
Update python dependencies to support Python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Join the [![Discord](https://img.shields.io/discord/778312862425939998?color=586
 ## Requirements
 - A [Teensy](https://www.pjrc.com/store/index.html) or Arduino
   - uses native keyboard library for Arduino and Joystick library for Teensy
-- Python 3.7-3.10 (needs updating for 3.11+)
+- Python 3.8-3.12
     - virtualenv
 - Node 12-16 (needs updating for 17+)
   - yarn

--- a/webui/server/requirements.txt
+++ b/webui/server/requirements.txt
@@ -1,9 +1,9 @@
-aiohttp==3.8.5
-async-timeout==4.0.2
-attrs==21.2.0
-chardet==4.0.0
-idna==3.2
-multidict==5.2.0
+aiohttp==3.9.3
+async-timeout==4.0.3
+attrs==23.2.0
+chardet==5.2.0
+idna==3.6
+multidict==6.0.5
 pyserial==3.4
-typing-extensions==3.10.0.0
-yarl==1.7.2
+typing-extensions==4.9.0
+yarl==1.9.4


### PR DESCRIPTION
Update all Python dependencies to latest stable versions.
Breaking changes mentioned in the changelogs are about dropping support for old Python versions.
WebUI tested and working on Windows 11 with Python 3.8 and 3.12. 

Python 3.7 will no longer install all of the dependencies (and has also reached end-of-life).

Dependency Changelogs:
* https://docs.aiohttp.org/en/stable/changes.html
* https://github.com/aio-libs/async-timeout/blob/master/CHANGES.rst
* https://www.attrs.org/en/stable/changelog.html
* https://github.com/chardet/chardet/releases
* https://github.com/kjd/idna/blob/master/HISTORY.rst
* https://github.com/aio-libs/multidict/blob/master/CHANGES.rst
* https://github.com/pyserial/pyserial/releases
* https://github.com/python/typing_extensions/blob/main/CHANGELOG.md
* https://github.com/aio-libs/yarl/blob/master/CHANGES.rst