### PR TITLE
Joystick support for RP2040-based boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Follow a guide like [fsr-pad-guide](https://github.com/Sereni/fsr-pad-guide) or 
 1. In Arduino IDE, set the `Tools` > `Board` to your microcontroller (e.g. `Teensy 4.0`)
 1. In Arduino IDE, set the `Tools` > `Port` to select the serial port for the plugged in microcontroller (e.g. `COM5` or `/dev/something`)
 1. Load [fsr.ino](./fsr.ino) in Arduino IDE.
-1. By default, [A0-A3 are the pins](https://forum.pjrc.com/teensy40_pinout1.png) used for the FSR sensors in this software. If you aren't using these pins [alter the SensorState array](./fsr.ino#L437-L442)
+1. By default, [A0-A3 are the pins](https://forum.pjrc.com/teensy40_pinout1.png) used for the FSR sensors in this software. If you aren't using these pins [alter the SensorState array](./fsr.ino#L509-L531)
 1. Push the code to the board
 
 ### Testing and using the serial monitor
@@ -92,3 +92,9 @@ Find this line, and remove the slashes at the beginning to uncomment it.
 ```c++
 #define USE_ARDUINO_JOYSTICK_LIBRARY
 ```
+
+## Support for RP2040
+
+The RP2040 is the microcontroller used by the Raspberry Pi Pico. The Pi Pico only exposes 3 analog input pins, but the RP2040 actually has 4. Various other RP2040 development boards do make it easy to access all 4 analog pins, which is more suitable for building a 4-panel dance pad.
+
+To run the FSR firmware on an RP2040-based device, install "Raspberry Pi Pico/RP2040" 3.6.1 or newer in the Arduino IDE boards manager. Make sure the "USB Stack" option in the Tools menu is set to "Pico SDK."

--- a/fsr.ino
+++ b/fsr.ino
@@ -62,8 +62,8 @@
   bool ButtonSend() {
     // Wait until send_now can send with minimal delay.
     // If it isn't ready, Joystick.send_now() will block.
-    // Since the Arduino-Pico Joystick library requests 10ms polling,
-    // that means send_now() could block for up to 10ms.
+    // Problems are most pronounced at slower polling rates since
+    // send_now() could block for a full polling interval.
     if (!tud_hid_ready()) {
       return false;
     } else {

--- a/fsr.ino
+++ b/fsr.ino
@@ -46,8 +46,8 @@
   #include "tusb.h"
   // Arduino-Pico defaults to 10ms polling interval (100Hz) but it can be
   // set to a shorter interval by declaring a usb_hid_poll_interval global.
-  // Set the interval to 1 for 1000Hz polling. Requires a newer release
-  // than 3.6.0. Older versions will always request a 10ms interval.
+  // Set the interval to 1 for 1000Hz polling. Requires Arduino-Pico 3.6.1
+  // or newer to work. Older versions will always request a 10ms interval.
   int usb_hid_poll_interval = 1;
   void ButtonStart() {
     Joystick.begin();

--- a/fsr.ino
+++ b/fsr.ino
@@ -23,6 +23,8 @@
     // it to be included explicitly.
     // Make sure to select Pico SDK for the Arduino-Pico USB stack.
     #include <Joystick.h>
+    // tiny usb is needed in order to wait for send_now to work.
+    #include "tusb.h"
   #endif
   void ButtonStart() {
     // Use Joystick.begin() for everything that's not Teensy 2.0.
@@ -38,6 +40,12 @@
     Joystick.button(button_num, 0);
   }
   void ButtonSend() {
+    #ifdef ARDUINO_ARCH_RP2040
+      // Wait for tiny usb to be ready.
+      // If it isn't, Joystick.send_now() will block until it is,
+      // for around 8ms (125 hz polling)
+      if (!tud_hid_ready()) { return; }
+    #endif
     Joystick.send_now();
   }
 #elif defined(USE_ARDUINO_JOYSTICK_LIBRARY)

--- a/fsr.ino
+++ b/fsr.ino
@@ -16,8 +16,14 @@
 // then uncomment the following line.
 // #define USE_ARDUINO_JOYSTICK_LIBRARY
 
-#if defined(CORE_TEENSY)
-  // Use the Joystick library for Teensy
+#if defined(CORE_TEENSY) || defined(ARDUINO_ARCH_RP2040)
+  // Use the Joystick library for Teensy or Arduino-Pico
+  #ifdef ARDUINO_ARCH_RP2040
+    // Teensy includes Joystick by default but Arduino-Pico requires
+    // it to be included explicitly.
+    // Make sure to select Pico SDK for the Arduino-Pico USB stack.
+    #include <Joystick.h>
+  #endif
   void ButtonStart() {
     // Use Joystick.begin() for everything that's not Teensy 2.0.
     #ifndef __AVR_ATmega32U4__

--- a/fsr.ino
+++ b/fsr.ino
@@ -44,6 +44,11 @@
   #include <Joystick.h>
   // Include tusb.h to get tud_hid_ready()
   #include "tusb.h"
+  // Arduino-Pico defaults to 10ms polling interval (100Hz) but it can be
+  // set to a shorter interval by declaring a usb_hid_poll_interval global.
+  // Set the interval to 1 for 1000Hz polling. Requires a newer release
+  // than 3.6.0. Older versions will always request a 10ms interval.
+  int usb_hid_poll_interval = 1;
   void ButtonStart() {
     Joystick.begin();
     Joystick.useManualSend(true);


### PR DESCRIPTION
Support running the firmware on RP2040-based boards such as the Arduino Pico, though the Pico itself is not recommended since it only has 3 analog pins.