### PR TITLE
Fix building for RP2040

### DIFF
--- a/fsr.ino
+++ b/fsr.ino
@@ -35,7 +35,7 @@
     Joystick.send_now();
     return true;
   }
-#elif defined(ARDUINO_ARCH_RP2040)
+#elif defined(ARDUINO_ARCH_RP2040) || defined(PICO_BOARD)
   // Use the Joystick library for Arduino-Pico
   // Teensy includes Joystick by default but Arduino-Pico requires
   // it to be included explicitly. The API is similar but it


### PR DESCRIPTION
Tested working on a Waveshare RP2040-Zero.

With the existing code, RP2040 users have to change `#elif defined(ARDUINO_ARCH_RP2040)` to `#elif 1`

With this change, after following setup instructions at https://github.com/earlephilhower/arduino-pico, everything works as expected.