### PR TITLE
Update RP2040 install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,4 +97,6 @@ Find this line, and remove the slashes at the beginning to uncomment it.
 
 The RP2040 is the microcontroller used by the Raspberry Pi Pico. The Pi Pico only exposes 3 analog input pins, but the RP2040 actually has 4. Various other RP2040 development boards do make it easy to access all 4 analog pins, which is more suitable for building a 4-panel dance pad.
 
-To run the FSR firmware on an RP2040-based device, install "Raspberry Pi Pico/RP2040" 3.6.1 or newer in the Arduino IDE boards manager. Make sure the "USB Stack" option in the Tools menu is set to "Pico SDK."
+To run the FSR firmware on an RP2040-based device, download the RP2040 Arduino Core from https://github.com/earlephilhower/arduino-pico, and follow the setup instructions.
+
+After installing the Arduino core, select your board from the Tools menu. It will be inside the **Raspberry Pi Pico/RP2040** group. Make sure the "USB Stack" option in the Tools menu is set to "Pico SDK."


### PR DESCRIPTION
Just built another RP2040-based FSR setup and realized the RP2040 instructions are not 100% complete - the link to the correct `Raspberry Pi Pico/RP2040` board definition is hidden in Discord messages currently. 

I've added a link to the needed RP2040 Arduino core, since the one downloaded from Arduino IDE's "Boards Manager" does not include an Arduino core and thus will not work with `fsr.ino`.

Removes the notice to make sure the version is at least 3.6.1, since that code is currently on 4.4.4 at the time of writing, so any version downloaded from this point on should be adequate for use.