### PR TITLE
Fix conflicting dependencies for aiohttp by removing yarl pinned version

### DIFF
--- a/webui/server/requirements.txt
+++ b/webui/server/requirements.txt
@@ -6,4 +6,4 @@ idna==3.7
 multidict==6.0.5
 pyserial==3.4
 typing-extensions==4.9.0
-yarl==1.9.4
+yarl


### PR DESCRIPTION
<img width="1132" height="209" alt="image" src="https://github.com/user-attachments/assets/59904ce3-15d7-47ed-b463-94fe63711d74" />

I helped a few people set up the FSR stuff recently and this always comes up.